### PR TITLE
Validação para apenas letras nos nomes e arrumando erros

### DIFF
--- a/app/models/ajudante.rb
+++ b/app/models/ajudante.rb
@@ -2,7 +2,7 @@ class Ajudante < ApplicationRecord
     has_many :servicos, :dependent => :nullify
     belongs_to :usuario
 
-    validates :nome, presence: true, length: {in:6..35}, numericality: false
+    validates :nome, presence: true, length: {in:6..35}, format: {with: /\A[a-zA-ZáàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ ]+\z/ }
     validates_cpf_format_of :cpf
     validates :cpf, uniqueness: true
     validates :contato, presence: true, length: {in:8..15}, numericality: {only_integer:true}

--- a/app/models/cliente.rb
+++ b/app/models/cliente.rb
@@ -3,7 +3,7 @@ class Cliente < ApplicationRecord
     has_many :servicos, :dependent => :restrict_with_error
     belongs_to :usuario
 
-    validates :nome, presence: true, length: {in:6..35}, numericality: false
+    validates :nome, presence: true, length: {in:6..35}, format: {with: /\A[a-zA-ZáàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ ]+\z/ }
     validates_cpf_format_of :cpf
     validates :cpf, uniqueness: true
     validates :contato, presence: true, length: {in:8..15}, numericality: {only_integer:true}

--- a/app/models/endereco.rb
+++ b/app/models/endereco.rb
@@ -1,6 +1,6 @@
 class Endereco < ApplicationRecord
 
-    validates :cidade,presence: true,  length: {in:3..35}
+    validates :cidade,presence: true,  length: {in:3..35}, format: {with: /\A[a-zA-ZáàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ ]+\z/ }
     validates :bairro,presence: true,  length: {in:4..35}
     validates :logradouro,presence: true,  length: {in:4..35}
     validates :complemento,presence: true,  length: {in:3..35}

--- a/app/models/usuario.rb
+++ b/app/models/usuario.rb
@@ -5,7 +5,7 @@ class Usuario < ApplicationRecord
     has_many :materials, :dependent => :destroy
     
     
-    validates :nome, presence: true,length: {in:6..35}, numericality: false
+    validates :nome, presence: true,length: {in:6..35}, format: {with: /\A[a-zA-ZáàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ ]+\z/ }
     validates_cpf_format_of :cpf
     validates :cpf, uniqueness: true
     validates :funcao, presence: true, length: {in:5..35}

--- a/features/material.feature
+++ b/features/material.feature
@@ -4,7 +4,7 @@ Feature: Material
   So that eu nao tenha que fazer isso manualmente
 
 Scenario: Cadastrar novo Material
-  Given existe um usuario ja cadastrado no sistema com o nome 'usuario001', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
+  Given existe um usuario ja cadastrado no sistema com o nome 'Usuario Teste', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
   And estou entrando no sistema com o login '91352091437' e senha 'password'
   When eu entro na pagina de material
   And clico em novo material
@@ -13,7 +13,7 @@ Scenario: Cadastrar novo Material
   Then eu vejo uma mensagem informando que o material foi criado com sucesso
 
 Scenario: Cadastrar Material com campo Preco vazio
-  Given existe um usuario ja cadastrado no sistema com o nome 'usuario001', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
+  Given existe um usuario ja cadastrado no sistema com o nome 'Usuario Teste', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
   And estou entrando no sistema com o login '91352091437' e senha 'password'
   When eu entro na pagina de material
   And clico em novo material
@@ -22,7 +22,7 @@ Scenario: Cadastrar Material com campo Preco vazio
   Then eu vejo uma mensagem informando que preco nao pode ficar em branco
 
 Scenario: Apagar Material
-  Given existe um usuario ja cadastrado no sistema com o nome 'usuario001', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
+  Given existe um usuario ja cadastrado no sistema com o nome 'Usuario Teste', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
   And estou entrando no sistema com o login '91352091437' e senha 'password'
   And existe um material com materiais 'Moldura de gesso' , descricao 'Moldura de 5 metros lisa' e preco '40'
   When eu entro na pagina de visualizar materiais
@@ -30,7 +30,7 @@ Scenario: Apagar Material
   Then eu vejo que o material 'Moldura de gesso' nao se encontra mais na pagina
 
 Scenario: Editar Material
-  Given existe um usuario ja cadastrado no sistema com o nome 'usuario001', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
+  Given existe um usuario ja cadastrado no sistema com o nome 'Usuario Teste', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
   And estou entrando no sistema com o login '91352091437' e senha 'password'
   And existe um material com materiais 'Moldura de gesso' , descricao 'Moldura de 5 metros lisa' e preco '40'
   When eu entro na pagina de visualizar materiais
@@ -40,7 +40,7 @@ Scenario: Editar Material
   Then Eu vejo uma mensagem informando que material foi editado com sucesso
 
 Scenario: Editar Material com campo materiais menor que o exigido
-  Given existe um usuario ja cadastrado no sistema com o nome 'usuario001', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
+  Given existe um usuario ja cadastrado no sistema com o nome 'Usuario Teste', CPF '91352091437', funcao 'Gesseiro' e senha 'password'
   And estou entrando no sistema com o login '91352091437' e senha 'password'
   And existe um material com materiais 'Moldura de gesso' , descricao 'Moldura de 5 metros lisa' e preco '40'
   When eu entro na pagina de visualizar materiais

--- a/test/models/cliente_test.rb
+++ b/test/models/cliente_test.rb
@@ -13,7 +13,7 @@ class ClienteTest < ActiveSupport::TestCase
 
       usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
       cpf: '37287511460',
       contato: '45214521',
       endereco_attributes:{ cidade: 'Garanhuns',
@@ -33,7 +33,7 @@ class ClienteTest < ActiveSupport::TestCase
 
       usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
       cpf: '37287511460',
       contato: '4521abcd',
       endereco_attributes:{ cidade: 'Garanhuns',
@@ -53,7 +53,7 @@ class ClienteTest < ActiveSupport::TestCase
 
       usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
       cpf: '372875114603',
       contato: '45214521',
       endereco_attributes:{ cidade: 'Garanhuns',
@@ -72,7 +72,7 @@ class ClienteTest < ActiveSupport::TestCase
 
       usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
       cpf: '12345678900',
       contato: '45214521',
       endereco_attributes:{ cidade: 'Garanhuns',

--- a/test/models/endereco_test.rb
+++ b/test/models/endereco_test.rb
@@ -12,7 +12,7 @@ class EnderecoTest < ActiveSupport::TestCase
     
     usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
     cpf: '37287511460',
     contato: '45214521',
     endereco_attributes:{ cidade: 'Garanhuns',
@@ -32,7 +32,7 @@ class EnderecoTest < ActiveSupport::TestCase
     
     usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
     cpf: '37287511460',
     contato: '45214521',
     endereco_attributes:{ cidade: 'Garanhuns',
@@ -52,7 +52,7 @@ class EnderecoTest < ActiveSupport::TestCase
     
     usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
     cpf: '37287511460',
     contato: '45214521',
     endereco_attributes:{ cidade: 'Ga',
@@ -70,7 +70,7 @@ class EnderecoTest < ActiveSupport::TestCase
     
     usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
     cpf: '37287511460',
     contato: '45214521',
     endereco_attributes:{ cidade: 'Ga',
@@ -89,7 +89,7 @@ class EnderecoTest < ActiveSupport::TestCase
     
     usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
     cpf: '37287511460',
     contato: '45214521',
     endereco_attributes:{ cidade: 'Garanhuns',
@@ -108,7 +108,7 @@ class EnderecoTest < ActiveSupport::TestCase
     
     usuario.save
 
-    cliente = Cliente.new nome: 'Cliente Teste 1',
+    cliente = Cliente.new nome: 'Cliente Teste',
     cpf: '37287511460',
     contato: '45214521',
     endereco_attributes:{bairro: 'Boa Vista',


### PR DESCRIPTION
Permitindo apenas letras nos campos de nomes de Cidade, Cliente, Ajudante e Usuario, e em seguinda arrumando os erros que existiam de testes/features com pessoas com nomes possuindo letras.